### PR TITLE
Search, test cases, travis config file fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,9 @@
 language: java
-jdk:
-  - openjdk7
+sudo: false
+
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
+
+jdk: oraclejdk8

--- a/src/main/java/org/ronsmits/omdbapi/SearchResult.java
+++ b/src/main/java/org/ronsmits/omdbapi/SearchResult.java
@@ -18,7 +18,8 @@ public class SearchResult implements Serializable{
 	private String year;
 	private String imdbId;
 	private String type;
-	
+	private String poster;
+
 	public String getTitle() {
 		return title;
 	}
@@ -46,4 +47,12 @@ public class SearchResult implements Serializable{
 	public void setType(String type) {
 		this.type = type;
 	}
+	public String getPoster() {
+		return poster;
+	}
+	@XmlElement(name = "Poster")
+	public void setPoster(String poster) {
+		this.poster = poster;
+	}
+
 }

--- a/src/test/java/org/ronsmits/omdbapi/TestOmdb.java
+++ b/src/test/java/org/ronsmits/omdbapi/TestOmdb.java
@@ -1,4 +1,4 @@
-package org.ronsmits.omdbapi;
+package com.omdbapi;
 
 import java.util.List;
 import java.util.logging.Level;
@@ -29,7 +29,7 @@ public class TestOmdb {
     @Test
     public void testFindBladeRunnerWithYear() throws OmdbMovieNotFoundException, OmdbConnectionErrorException, OmdbSyntaxErrorException {
 	List<SearchResult> search = new Omdb().year(1982).type(MovieType.movie).search("blade runner");
-	assertEquals(1, search.size());
+	assertEquals(3, search.size());
 	assertEquals("Blade Runner", search.get(0).getTitle());
 	assertEquals("1982", search.get(0).getYear());
     }
@@ -60,8 +60,7 @@ public class TestOmdb {
     @Test
     public void testGetBladeRunnerWith2Types() throws OmdbMovieNotFoundException, OmdbConnectionErrorException, OmdbSyntaxErrorException {
 	List<SearchResult> search = new Omdb().type(MovieType.episode).type(MovieType.game).search("blade runner");
-
-	assertEquals(3, search.size());
+	assertEquals(1, search.size());
     }
 
 }


### PR DESCRIPTION
- Updated OMDb API now returns 5 fields now i.e., Title, Year, imdbID, Type, Poster. Code is updated to accommodate Poster field.
- Test cases updated as per the new data received from API.
- Travis CI config file updated to use new JDK.